### PR TITLE
Fix check in process_view for default graphiql value

### DIFF
--- a/graphiql_strawberry_debug_toolbar/middleware.py
+++ b/graphiql_strawberry_debug_toolbar/middleware.py
@@ -54,7 +54,7 @@ class DebugToolbarMiddleware(BaseMiddleware):
         if (
             hasattr(view_func, "view_class")
             and issubclass(view_func.view_class, GraphQLView)
-            and view_func.view_initkwargs.get("graphiql")
+            and view_func.view_initkwargs.get("graphiql", True)
         ):
             request._graphiql = True
 


### PR DESCRIPTION
The default for the `graphiql` keyword argument to `GraphQLView` is
`True`.

ref: https://github.com/strawberry-graphql/strawberry/blob/05c94aea86d5c44e226d0f5a0d453079308ce8b9/strawberry/django/views.py#L54
ref: https://github.com/strawberry-graphql/strawberry/commit/701c51f81f2558edb1dc2930e53272586a477c27